### PR TITLE
Enable MPEG-Dash content

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,6 +2,7 @@
 <addon id="c4valli.fcast.receiver" name="Kodi FCast Receiver" version="1.0.0" provider-name="sguerrini97">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
+		<import addon="inputstream.adaptive" version="20.3.1"/>
 	</requires>
 	<extension point="xbmc.service" library="main.py" />
 	<extension point="xbmc.addon.metadata">


### PR DESCRIPTION
I was able to get MPEG-Dash working (at least with Grayjay). I took a look at how the YouTube addon does MPEG-Dash. It uses the InputStream Adaptive addon, so I marked that as a requirement in `addon.xml`.

For delivering, I chose the same approach as `test.py`, making an HTTP server to deliver the MPD manifest via a URL, which was accepted by InputStream Adaptive.

This also fixes a bug with seeking, where if the client sends many seek packets, Kodi would normally freeze up as it tries to process them all. Instead, only the last one send within a 150ms timespan gets through.

There is one bug in this code that I couldn't resolve. When sending a Stop packet from the FCast client, Kodi freezes up for about 30 seconds. I can't see anything in my code that would cause blocking. My guess is it has to do with the HTTP request to the mdp manifest. Some related logs are below, which appear after the stop packet:
```
CCurlFile::Stat - <http://localhost:34755/stream.mpd> Failed: Timeout was reached(28)
...
127.0.0.1 - - [19/Nov/2023 21:50:16] code 501, message Unsupported method ('HEAD')
127.0.0.1 - - [19/Nov/2023 21:50:16] "HEAD /stream.mpd HTTP/1.1" 501 -
127.0.0.1 - - [19/Nov/2023 21:50:16] code 501, message Unsupported method ('HEAD')
127.0.0.1 - - [19/Nov/2023 21:50:16] "HEAD /stream.mpd HTTP/1.1" 501 -
```